### PR TITLE
Switch docker image to unofficial one, upgrade version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM klakegg/hugo:0.81.0-ext-ubuntu AS builder
+FROM hugomods/hugo:0.135.0 AS builder
 
 ARG HUGO_ENV=default
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,8 @@ version: '3.8'
 
 services:
   hugo:
-    image: klakegg/hugo:0.81.0-ext-ubuntu
-    command: server -p 8042 --bind 0.0.0.0
+    image: hugomods/hugo:0.135.0
+    command: hugo server -p 8042 --bind 0.0.0.0
     ports:
       - 8042:8042
     volumes:

--- a/sbb-start-dev.sh
+++ b/sbb-start-dev.sh
@@ -2,4 +2,4 @@
 
 echo starting hugo-dev on http://localhost:8095
 
-podman run --rm --interactive --publish 8095:8095 --name hugo-dev -v %cd%:/src klakegg/hugo:0.81.0-ext-ubuntu server -p 8095 --bind 0.0.0.0
+podman run --rm --interactive --publish 8095:8095 --name hugo-dev -v %cd%:/src hugomods/hugo:0.135.0 server -p 8095 --bind 0.0.0.0

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -2,12 +2,12 @@
 
 echo starting hugo-dev on http://localhost:8095
 
-export HUGO_VERSION=$(grep "FROM klakegg/hugo" Dockerfile | sed 's/FROM klakegg\/hugo://g' | sed 's/ AS builder//g')
+export HUGO_VERSION=$(grep "FROM hugomods/hugo" Dockerfile | sed 's/FROM hugomods\/hugo://g' | sed 's/ AS builder//g')
 docker run \
   --rm --interactive \
   --publish 8095:8095 \
   --name hugo-dev \
   -v $(pwd):/src \
-  klakegg/hugo:${HUGO_VERSION} \
+  hugomods/hugo:${HUGO_VERSION} \
   server -p 8095 --bind 0.0.0.0
 

--- a/start-hugu.bat
+++ b/start-hugu.bat
@@ -1,2 +1,2 @@
 wsl podman rm hugo-dev -f
-wsl podman run   --rm --interactive   --publish 8095:8095   --name hugo-dev   -v $(pwd):/src   klakegg/hugo:0.81.0-ext-ubuntu   server -p 8095 --bind 0.0.0.0
+wsl podman run   --rm --interactive   --publish 8095:8095   --name hugo-dev   -v $(pwd):/src  hugomods/hugo:0.135.0   server -p 8095 --bind 0.0.0.0


### PR DESCRIPTION
Switched the docker image to the inofficial one from [hugomods](https://docker.hugomods.com/docs/) and upgraded it to 0.135.0

I've only tested it with ` docker compose up` so far, as this is the only thing I am using. 