### PR TITLE
Remove unused command from pipeline

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -17,7 +17,6 @@ jobs:
         with:
           name: quality-check-build
           path: ./public
-      - run: ls -ahl
       - name: Run htmltest
         uses: wjdp/htmltest-action@master
         with:


### PR DESCRIPTION
Remove `ls` command, which was once added for debugging.